### PR TITLE
优化路线；新增清除锄大地记录

### DIFF
--- a/config/world_patrol/P01_KJZHT/R03_SRCD_R01_HMZL.yml
+++ b/config/world_patrol/P01_KJZHT/R03_SRCD_R01_HMZL.yml
@@ -6,7 +6,7 @@ tp: '毁灭之蕾拟造花萼赤'
 route:
   - op: 'move'
     data: [318, 445, -1]
-  - op: 'move'
+  - op: 'slow_move'
     data: [257, 445]
   - op: 'move'
     data: [257, 325]

--- a/config/world_patrol/P02_YLL6/R03_BYTL_R01_GDJZ.yml
+++ b/config/world_patrol/P02_YLL6/R03_BYTL_R01_GDJZ.yml
@@ -25,7 +25,10 @@ route:
     data: [746, 680]
   - op: 'patrol'
   - op: 'move'
-    data: [746, 835]
+    data: [747, 717]
+  - op: 'patrol'
+  - op: 'move'
+    data: [746, 788]
   - op: 'patrol'
   - op: 'move'
     data: [686, 851]

--- a/config/world_patrol/P02_YLL6/R05_CXHL_R03_MLZX_2.yml
+++ b/config/world_patrol/P02_YLL6/R05_CXHL_R03_MLZX_2.yml
@@ -13,7 +13,7 @@ route:
   - op: 'move'
     data: [658, 546]
   - op: 'move'
-    data: [699, 585]
+    data: [678, 567]
   - op: 'patrol'
   - op: 'move'
     data: [740, 627]

--- a/config/world_patrol/P02_YLL6/R10_DKQ_R02_FKD.yml
+++ b/config/world_patrol/P02_YLL6/R10_DKQ_R02_FKD.yml
@@ -8,6 +8,7 @@ route:
     data: [616, 657]
   - op: 'move'
     data: [679, 642]
+  - op: 'patrol'
   - op: 'move'
     data: [694, 574]
   - op: 'patrol'

--- a/config/world_patrol/P02_YLL6/R12_JXJL_R01_TXZL.yml
+++ b/config/world_patrol/P02_YLL6/R12_JXJL_R01_TXZL.yml
@@ -13,27 +13,31 @@ route:
     data: [402, 533]
   - op: 'move'
     data: [410, 485]
-  - op: 'move'
+  - op: 'slow_move'
     data: [410, 420]
   - op: 'patrol'
-  - op: 'move'
+  - op: 'slow_move'
     data: [415, 482]
-  - op: 'move'
+  - op: 'slow_move'
     data: [433, 482]
   - op: 'move'
     data: [612, 487]
-  - op: 'move'
+  - op: 'slow_move'
     data: [635, 486]
-  - op: 'move'
+  - op: 'slow_move'
     data: [676, 493]
   - op: 'move'
     data: [724, 451]
   - op: 'patrol'
-  - op: 'move'
+  - op: 'slow_move'
     data: [715, 423]
+  - op: 'slow_move'
+    data: [688, 419]
   - op: 'patrol'
-  - op: 'move'
+  - op: 'slow_move'
+    data: [715, 423]
+  - op: 'slow_move'
     data: [737, 477]
-  - op: 'move'
+  - op: 'slow_move'
     data: [771, 500]
   - op: 'patrol'

--- a/config/world_patrol/P03_XZLF/R02_LYD_R01_JYF.yml
+++ b/config/world_patrol/P03_XZLF/R02_LYD_R01_JYF.yml
@@ -18,6 +18,7 @@ route:
     data: [597, 661]
   - op: 'move'
     data: [555, 660]
+  - op: 'patrol'
   - op: 'move'
     data: [520, 660]
   - op: 'patrol'

--- a/config/world_patrol/P03_XZLF/R07_GZS_R02_GWYTD.yml
+++ b/config/world_patrol/P03_XZLF/R07_GZS_R02_GWYTD.yml
@@ -13,6 +13,7 @@ route:
   - op: 'patrol'
   - op: 'move'
     data: [540, 639]
+  - op: 'patrol'
   - op: 'move'
     data: [541, 744]
   - op: 'move'

--- a/config/world_patrol/P03_XZLF/R08_DDS_R01_TZDS.yml
+++ b/config/world_patrol/P03_XZLF/R08_DDS_R01_TZDS.yml
@@ -11,16 +11,17 @@ route:
   - op: 'move'
     data: [465, 596]
   - op: 'move'
-    data: [455, 606]
+    data: [454, 582]
   - op: 'move'
     data: [441, 597]
   - op: 'move'
     data: [390, 596]
   - op: 'move'
-    data: [346, 557]
+    data: [362, 557]
   - op: 'patrol'
   - op: 'move'
-    data: [323, 559]
+    data: [333, 524]
+  - op: 'patrol'
   - op: 'move'
     data: [317, 527]
   - op: 'move'

--- a/config/world_patrol/P03_XZLF/R08_DDS_R04_YSZJ.yml
+++ b/config/world_patrol/P03_XZLF/R08_DDS_R04_YSZJ.yml
@@ -31,12 +31,16 @@ route:
   - op: 'move'
     data: [725, 1224]
   - op: 'move'
-    data: [744, 1155]
+    data: [742, 1132]
   - op: 'patrol'
   - op: 'move'
     data: [781, 1155]
+  - op: 'patrol'
   - op: 'move'
     data: [782, 1106]
+  - op: 'patrol'
+  - op: 'move'
+    data: [741, 1103]
   - op: 'patrol'
   - op: 'move'
     data: [754, 1053]

--- a/config/world_patrol/P03_XZLF/R09_LYJ_R03_GHGX.yml
+++ b/config/world_patrol/P03_XZLF/R09_LYJ_R03_GHGX.yml
@@ -29,8 +29,8 @@ route:
   - op: 'patrol'
   - op: 'move'
     data: [919, 607]
-  - op: 'move'
-    data: [917, 696]
+  - op: 'slow_move'
+    data: [917, 676]
   - op: 'patrol'
   - op: 'move'
     data: [882, 671]
@@ -39,7 +39,9 @@ route:
   - op: 'move'
     data: [793, 602]
   - op: 'move'
-    data: [698, 586]
+    data: [734, 591]
+  - op: 'slow_move'
+    data: [711, 585]
   - op: 'patrol'
   - op: 'move'
     data: [692, 549]

--- a/config/world_patrol/P03_XZLF/R10_SY_R02_THLHM_2.yml
+++ b/config/world_patrol/P03_XZLF/R10_SY_R02_THLHM_2.yml
@@ -6,24 +6,44 @@ tp: '谈狐林后门'
 route:
   - op: 'move'
     data: [234, 549]
-  - op: 'move'
+  - op: 'slow_move'
+    data: [254, 551]
+  - op: 'patrol'
+  - op: 'slow_move'
     data: [234, 567]
   - op: 'patrol'
-  - op: 'move'
+  - op: 'slow_move'
     data: [241, 597]
   - op: 'move'
     data: [266, 649]
-  - op: 'move'
+  - op: 'slow_move'
+    data: [272, 677]
+  - op: 'slow_move'
     data: [290, 700]
   - op: 'move'
     data: [316, 758]
+  - op: 'slow_move'
+    data: [292, 767]
+  - op: 'slow_move'
+    data: [278, 743]
+  - op: 'slow_move'
+    data: [255, 746]
+  - op: 'patrol'
+  - op: 'slow_move'
+    data: [231, 764]
+  - op: 'slow_move'
+    data: [214, 786]
   - op: 'move'
-    data: [351, 760]
+    data: [206, 836]
   - op: 'move'
-    data: [380, 802]
+    data: [237, 872]
+  - op: 'move'
+    data: [300, 864]
   - op: 'patrol'
   - op: 'move'
-    data: [368, 841]
+    data: [359, 861]
   - op: 'move'
-    data: [360, 860]
+    data: [380, 817]
+  - op: 'slow_move'
+    data: [375, 793]
   - op: 'patrol'

--- a/run.bat
+++ b/run.bat
@@ -5,8 +5,9 @@ cd /D %~dp0
 
 echo 如无反应 可切换使用管理员权限运行脚本
 
-set local_python=%~dp0.env\venv\Scripts\python.exe
+REM set local_python=%~dp0.env\venv\Scripts\python.exe
 set PYTHONPATH=%~dp0/src
 
-!local_python! src/gui/app.py
+REM !local_python! src/gui/app.py
+python src/gui/app.py
 pause

--- a/src/basic/config_utils.py
+++ b/src/basic/config_utils.py
@@ -1,7 +1,7 @@
 import os
 from ctypes import Union
 from typing import List
-
+from basic.log_utils import log
 import yaml
 
 from basic import os_utils
@@ -43,9 +43,12 @@ def read_config(name: str, sample: bool = True, sub_dir: List[str] = None):
     if os.path.exists(path):
         with open(path, 'r', encoding='utf-8') as file:
             data = yaml.safe_load(file)
+        return data
     if data is None and sample:
         data = read_sample_config(name, sub_dir=sub_dir)
-    return data
+        return data
+    else:
+        log.warning('找不到配置文件 %s' % path)
 
 
 def read_sample_config(name: str, sub_dir: List[str] = None):
@@ -125,3 +128,17 @@ def async_sample(name: str, sub_dir: List[str] = None) -> dict:
     save_config(name, config)
     return config
 
+def clear_config_file(name: str, sub_dir: List[str] = None):
+    """
+    清空文件内容
+    :param name: 文件名称,不带后缀
+    :param sub_dir: 子目录
+    :return:
+    """
+    path = get_config_file_path(name, sub_dir=sub_dir)
+    if os.path.exists(path):
+        with open(path, 'w') as f:
+            f.truncate()
+            log.warning('文件 %s 已清空' % path)
+    else:
+        log.warning('文件 %s 不存在' % path)

--- a/src/basic/img/cv2_utils.py
+++ b/src/basic/img/cv2_utils.py
@@ -4,6 +4,7 @@ from typing import Union, List
 import cv2
 import numpy as np
 from cv2.typing import MatLike
+from PIL import Image
 
 from basic import Rect, os_utils
 from basic.img import MatchResult, MatchResultList
@@ -515,3 +516,25 @@ def scale_image(img: MatLike, scale: float = None, copy: bool = True):
         return img.copy() if copy else img
     target_size = (int(img.shape[0] * scale), int(img.shape[1] * scale))
     return cv2.resize(img, target_size)
+
+
+def show_image_ipython(img: MatLike,
+               rects: Union[MatchResult, MatchResultList] = None) -> Image.Image:
+    """
+    显示一张图片,方便在jupyter窗口中显示
+    :param img: 图片
+    :param rects: 需要画出来的框
+    :return:
+    """
+    to_show = img
+
+    if rects is not None:
+        to_show = img.copy()
+        if type(rects) == MatchResult:
+            cv2.rectangle(to_show, (rects.x, rects.y), (rects.x + rects.w, rects.y + rects.h), (255, 255, 255), 1)
+        elif type(rects) == MatchResultList:
+            for i in rects:
+                cv2.rectangle(to_show, (i.x, i.y), (i.x + i.w, i.y + i.h), (255, 255, 255), 1)
+
+    opencv_image_rgb = cv2.cvtColor(to_show, cv2.COLOR_BGR2RGB)
+    return Image.fromarray(opencv_image_rgb)

--- a/src/basic/os_utils.py
+++ b/src/basic/os_utils.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import sys
+import warnings
 
 
 def join_dir_path_with_mk(path: str, *subs) -> str:
@@ -16,6 +17,7 @@ def join_dir_path_with_mk(path: str, *subs) -> str:
         target_path = os.path.join(target_path, sub)
         if not os.path.exists(target_path):
             os.mkdir(target_path)
+            warnings.warn("创建了文件夹{}, 请确认理解此步操作。".format(target_path), UserWarning)
     return target_path
 
 

--- a/src/gui/world_patrol/world_patrol_run_view.py
+++ b/src/gui/world_patrol/world_patrol_run_view.py
@@ -3,6 +3,7 @@ from typing import List
 import flet as ft
 
 from basic.i18_utils import gt
+from basic.config_utils import clear_config_file
 from gui.sr_app_view import SrAppView
 from sr.app.world_patrol import WorldPatrolWhitelist, load_all_whitelist_id
 from sr.app.world_patrol.world_patrol_app import WorldPatrol
@@ -23,6 +24,7 @@ class WorldPatrolRunView(SrAppView):
         self.diy_part.content = ft.Column(spacing=5, controls=[
             ft.Container(content=settings_text),
             ft.Container(content=self.whitelist_dropdown),
+            ft.ElevatedButton(text="清除锄大地记录", on_click=self.clean_world_patrol_record)
         ])
 
     def on_rail_chosen(self, e):
@@ -37,6 +39,9 @@ class WorldPatrolRunView(SrAppView):
             options.append(opt)
         self.whitelist_dropdown.options = options
 
+    def clean_world_patrol_record(self, e):
+        clear_config_file(name="world_patrol", sub_dir=["app_run_record"])
+        
     def run_app(self):
         whitelist: WorldPatrolWhitelist = None
         if self.whitelist_dropdown.value is not None and self.whitelist_dropdown.value != 'none':


### PR DESCRIPTION
优化已有路线，测试环境是

1. 远程角色开怪，驭空，三月七，布洛妮娅等
2. 设置了开启疾跑，在容易卡死的地方设置慢跑
3. 在容易漏怪的地方多加了判断点位

新增清除锄大地记录按钮，方便多账号玩家重复使用。
修改了部分basic函数，增加warning。
 